### PR TITLE
Adjust ice to liquid density in ice mass calculation

### DIFF
--- a/src/biogeophys/TotalWaterAndHeatMod.F90
+++ b/src/biogeophys/TotalWaterAndHeatMod.F90
@@ -518,7 +518,7 @@ contains
           c = filter_c(fc)
           ! calculate lake liq and ice content per lake layer first
           h2olak_liq = dz_lake(c,j) * denh2o * (1 - lake_icefrac(c,j))
-          h2olak_ice = dz_lake(c,j) * denice * lake_icefrac(c,j)
+          h2olak_ice = dz_lake(c,j) * denh2o * lake_icefrac(c,j) ! use water density of liquid water as layer depth is not adjusted
           
           liquid_mass(c) = liquid_mass(c) + h2olak_liq
           ice_mass(c) = ice_mass(c) + h2olak_ice

--- a/src/biogeophys/TotalWaterAndHeatMod.F90
+++ b/src/biogeophys/TotalWaterAndHeatMod.F90
@@ -1086,7 +1086,8 @@ contains
                 heat_liquid = lake_heat_liquid(c), &
                 latent_heat_liquid = lake_latent_heat_liquid(c))
             ! ice heat
-            h2olak_ice = dz_lake(c,j) * denice * lake_icefrac(c,j)      
+            ! use water density as lake layer does not adjust
+            h2olak_ice = dz_lake(c,j) * denh2o * lake_icefrac(c,j)      
             lake_heat_ice(c) = lake_heat_ice(c) + & 
                 TempToHeat(temp=t_lake(c,j), cv = (h2olak_ice * cpice))
         end do


### PR DESCRIPTION

### Description of changes
Adjust ice to liquid density in ice mass calculation, as lake layer is not adjusted for change in density. 

### Specific notes

Contributors other than yourself, if any: 

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for gnu/pgi and hobart for gnu/pgi/nag is the standard for tags on master)

**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
